### PR TITLE
Compatibility fixes for date fns/tz

### DIFF
--- a/src/scripts/replace_date.ts
+++ b/src/scripts/replace_date.ts
@@ -1,6 +1,6 @@
 declare const __EXT_VERSION__: string
 ;(() => {
-    console.log(`injected content-script (version ${__EXT_VERSION__}) for host ${window.location.host}`)
+    console.log(`Time Travel: injected content-script (version ${__EXT_VERSION__}) for host ${window.location.host}`)
     if (window['__timeTravelCheckToggle'] !== undefined) {
         // this can happen if multiple versions of the extension are installed
         console.log('content script was already injected, aborting.')
@@ -174,12 +174,12 @@ declare const __EXT_VERSION__: string
     const timeTravelCheckToggle = () => {
         const fakeDate = getFromStorage(FAKE_DATE_STORAGE_KEY)
         if (fakeDate !== null) {
-            console.log(`Enabling Time Travel (fake date: ${fakeDate})`)
+            console.log(`Time Travel: Enabling fake date: ${fakeDate}`)
             // eslint-disable-next-line no-global-assign
             Date = FakeDate as DateConstructor
             Intl.DateTimeFormat = FakeIntlDateTimeFormat as typeof Intl.DateTimeFormat
         } else {
-            console.log('Disabling Time Travel')
+            console.log('Time Travel: Disabling')
             // eslint-disable-next-line no-global-assign
             Date = originalDate
             Intl.DateTimeFormat = OriginalIntlDateTimeFormat

--- a/src/scripts/replace_date.ts
+++ b/src/scripts/replace_date.ts
@@ -3,7 +3,7 @@ declare const __EXT_VERSION__: string
     console.log(`Time Travel: injected content-script (version ${__EXT_VERSION__}) for host ${window.location.host}`)
     if (window['__timeTravelCheckToggle'] !== undefined) {
         // this can happen if multiple versions of the extension are installed
-        console.log('content script was already injected, aborting.')
+        console.log('Time Travel: content script was already injected, aborting.')
         return
     }
 

--- a/src/scripts/replace_date.ts
+++ b/src/scripts/replace_date.ts
@@ -57,18 +57,6 @@ declare const __EXT_VERSION__: string
         }
     }
 
-    /** set properties  on given prototype */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    function addProperties(proto: any, props: object) {
-        Reflect.ownKeys(props).forEach((key) =>
-            Object.defineProperty(proto, key, {
-                configurable: true,
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                value: (props as any)[key],
-            })
-        )
-    }
-
     // ==================== Date replacement ====================
 
     const OriginalDate = Date
@@ -142,12 +130,10 @@ declare const __EXT_VERSION__: string
         return this._originalObject.resolvedOptions()
     }
 
-    addProperties(FakeIntlDateTimeFormat.prototype, {
-        [Symbol.toStringTag]: 'Intl.DateTimeFormat',
-    })
+    FakeIntlDateTimeFormat.prototype[Symbol.toStringTag] = 'Intl.DateTimeFormat'
 
-    //static methods
-    FakeIntlDateTimeFormat.supportedLocalesOf = Intl.DateTimeFormat.supportedLocalesOf
+    // static properties
+    Object.setPrototypeOf(FakeIntlDateTimeFormat, Intl.DateTimeFormat)
 
     // ==================== toggle logic for FakeDate / FakeIntlDateTimeFormat ====================
 

--- a/src/scripts/replace_date.ts
+++ b/src/scripts/replace_date.ts
@@ -73,38 +73,17 @@ declare const __EXT_VERSION__: string
 
     const OriginalDate = Date
     // Date constructor, needs to be a function to allow both constructing (`new Date()`) and calling without new: `Date()`
-    function FakeDate(
-        yearOrObject?: number | string | Date,
-        monthIndex?: number,
-        date?: number,
-        hours?: number,
-        minutes?: number,
-        seconds?: number,
-        ms?: number
-    ) {
+    function FakeDate(...args: unknown[]) {
         if (!new.target) {
             // `Date()` invoked without 'new', return current time string
             return new Date().toString()
         }
 
-        let returnDate
-        if (yearOrObject === undefined) {
-            returnDate = maybeFakeNowDate()
-        } else if (monthIndex === undefined) {
-            returnDate = new OriginalDate(yearOrObject)
-        } else if (date === undefined) {
-            returnDate = new OriginalDate(yearOrObject as number, monthIndex)
-        } else if (hours === undefined) {
-            returnDate = new OriginalDate(yearOrObject as number, monthIndex, date)
-        } else if (minutes === undefined) {
-            returnDate = new OriginalDate(yearOrObject as number, monthIndex, date, hours)
-        } else if (seconds === undefined) {
-            returnDate = new OriginalDate(yearOrObject as number, monthIndex, date, hours, minutes)
-        } else if (ms === undefined) {
-            returnDate = new OriginalDate(yearOrObject as number, monthIndex, date, hours, minutes, seconds)
-        } else {
-            returnDate = new OriginalDate(yearOrObject as number, monthIndex, date, hours, minutes, seconds, ms)
+        if (args.length === 0) {
+            args = [maybeFakeNowDate()]
         }
+        // @ts-expect-error: let original Date constructor handle the arguments
+        const returnDate = new OriginalDate(...args)
 
         // for `new SomeClassDerivedFromDate()`, make sure we return something that is an instance of SomeClassDerivedFromDate
         Object.setPrototypeOf(returnDate, new.target.prototype)

--- a/src/scripts/replace_date.ts
+++ b/src/scripts/replace_date.ts
@@ -105,14 +105,13 @@ declare const __EXT_VERSION__: string
         _originalObject: Intl.DateTimeFormat
     }
     function FakeIntlDateTimeFormat(
-        this: FakeIntlDateTimeFormat | void,
+        this: FakeIntlDateTimeFormat,
         locale?: string | string[],
         options?: Intl.DateTimeFormatOptions
     ) {
-        if (!(this instanceof Intl.DateTimeFormat)) {
+        if (!new.target) {
             //invoked without 'new'
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            return new (FakeIntlDateTimeFormat as any)(locale, options)
+            return new Intl.DateTimeFormat(locale, options)
         }
         this._originalObject = OriginalIntlDateTimeFormat(locale, options)
 

--- a/src/scripts/replace_date.ts
+++ b/src/scripts/replace_date.ts
@@ -41,7 +41,7 @@ declare const __EXT_VERSION__: string
      * This will either be the real current time (extension off),
      * or the fake time, stopped or ticking (extension on).
      */
-    function maybeFakeNowDate(): Date {
+    function fakeNowDate(): Date {
         const fakeDate = getFromStorage(FAKE_DATE_STORAGE_KEY)
         if (fakeDate !== null) {
             const fakeDateObject = new OriginalDate(fakeDate)
@@ -80,7 +80,7 @@ declare const __EXT_VERSION__: string
         }
 
         if (args.length === 0) {
-            args = [maybeFakeNowDate()]
+            args = [fakeNowDate()]
         }
         // @ts-expect-error: let original Date constructor handle the arguments
         const returnDate = new OriginalDate(...args)
@@ -127,10 +127,10 @@ declare const __EXT_VERSION__: string
     }
 
     function format(this: FakeIntlDateTimeFormat, date?: Date) {
-        return this._originalObject.format(date ?? new Date(FakeDate.now()))
+        return this._originalObject.format(date ?? fakeNowDate())
     }
     function formatToParts(this: FakeIntlDateTimeFormat, date?: Date | number): Intl.DateTimeFormatPart[] {
-        return this._originalObject.formatToParts(date ?? new Date(FakeDate.now()))
+        return this._originalObject.formatToParts(date ?? fakeNowDate())
     }
     type RangeDate = Date | number | bigint
     function formatRange(this: FakeIntlDateTimeFormat, startDate: RangeDate, endDate: RangeDate) {

--- a/src/scripts/replace_date.ts
+++ b/src/scripts/replace_date.ts
@@ -36,6 +36,27 @@ declare const __EXT_VERSION__: string
         }
     }
 
+    /** return the current date/time we want the page to see.
+     *
+     * This will either be the real current time (extension off),
+     * or the fake time, stopped or ticking (extension on).
+     */
+    function maybeFakeNowDate(): Date {
+        const fakeDate = getFromStorage(FAKE_DATE_STORAGE_KEY)
+        if (fakeDate !== null) {
+            const fakeDateObject = new originalDate(fakeDate)
+            const startTimestamp = getTickStartTimestamp()
+            if (startTimestamp === null) {
+                return fakeDateObject
+            } else {
+                const elapsed = originalDate.now() - startTimestamp
+                return new originalDate(fakeDateObject.getTime() + elapsed)
+            }
+        } else {
+            return new originalDate()
+        }
+    }
+
     /** set properties  on given prototype */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     function addProperties(proto: any, props: object) {
@@ -50,53 +71,50 @@ declare const __EXT_VERSION__: string
 
     // ==================== Date replacement ====================
 
-    const OriginalDate = Date
-
-    /* eslint-disable no-global-assign */
-    class FakeDate extends Date {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        constructor(...args: any[]) {
-            if (args.length === 0) {
-                args = [FakeDate.now()]
-            }
-            // @ts-expect-error: let native Date handle the details
-            super(...args)
-        }
-
-        /** return the current date/time we want the page to see, in ms since epoch
-         *
-         * This will either be the real current time (extension off),
-         * or the fake time, stopped or ticking (extension on).
-         */
-        static now() {
-            const fakeDate = getFromStorage(FAKE_DATE_STORAGE_KEY)
-            if (fakeDate) {
-                const fakeDateObject = new OriginalDate(fakeDate)
-                const startTimestamp = getTickStartTimestamp()
-                if (startTimestamp === null) {
-                    return fakeDateObject.getTime()
-                } else {
-                    const elapsed = OriginalDate.now() - startTimestamp
-                    return fakeDateObject.getTime() + elapsed
-                }
-            } else {
-                return OriginalDate.now()
-            }
-        }
-    }
-
-    function FakeDateConstructor(this: FakeDate | void) {
+    const originalDate = Date
+    // Date constructor, needs to be a function to allow both constructing (`new Date()`) and calling without new: `Date()`
+    function FakeDate(
+        this: Date | void,
+        yearOrObject?: number | string | Date,
+        monthIndex?: number,
+        date?: number,
+        hours?: number,
+        minutes?: number,
+        seconds?: number,
+        ms?: number
+    ) {
         if (!(this instanceof Date)) {
             //invoked without 'new'
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return new (FakeDate as any)().toString()
         }
 
-        return this
+        if (yearOrObject === undefined) {
+            return maybeFakeNowDate()
+        } else if (monthIndex === undefined) {
+            return new originalDate(yearOrObject)
+        } else if (date === undefined) {
+            return new originalDate(yearOrObject as number, monthIndex)
+        } else if (hours === undefined) {
+            return new originalDate(yearOrObject as number, monthIndex, date)
+        } else if (minutes === undefined) {
+            return new originalDate(yearOrObject as number, monthIndex, date, hours)
+        } else if (seconds === undefined) {
+            return new originalDate(yearOrObject as number, monthIndex, date, hours, minutes)
+        } else if (ms === undefined) {
+            return new originalDate(yearOrObject as number, monthIndex, date, hours, minutes, seconds)
+        } else {
+            return new originalDate(yearOrObject as number, monthIndex, date, hours, minutes, seconds, ms)
+        }
     }
 
-    // TODO doing this fixes only explicit calls to Date.prototype.constructor...
-    FakeDate.prototype.constructor = FakeDateConstructor
+    FakeDate.prototype = Date.prototype
+    FakeDate.prototype.constructor = FakeDate
+
+    //static methods
+    FakeDate.parse = Date.parse
+    FakeDate.UTC = Date.UTC
+    FakeDate.now = () => new Date().getTime()
 
     // ==================== Intl.DateTimeFormat replacement ====================
 
@@ -163,7 +181,7 @@ declare const __EXT_VERSION__: string
         } else {
             console.log('Time Travel: Disabling')
             // eslint-disable-next-line no-global-assign
-            Date = OriginalDate
+            Date = originalDate
             Intl.DateTimeFormat = OriginalIntlDateTimeFormat
         }
     }

--- a/src/scripts/replace_date.ts
+++ b/src/scripts/replace_date.ts
@@ -74,7 +74,6 @@ declare const __EXT_VERSION__: string
     const OriginalDate = Date
     // Date constructor, needs to be a function to allow both constructing (`new Date()`) and calling without new: `Date()`
     function FakeDate(
-        this: Date | void,
         yearOrObject?: number | string | Date,
         monthIndex?: number,
         date?: number,
@@ -83,10 +82,9 @@ declare const __EXT_VERSION__: string
         seconds?: number,
         ms?: number
     ) {
-        if (!(this instanceof Date)) {
-            //invoked without 'new'
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            return new (FakeDate as any)().toString()
+        if (!new.target) {
+            // `Date()` invoked without 'new', return current time string
+            return new Date().toString()
         }
 
         let returnDate

--- a/src/test/date-fns.html
+++ b/src/test/date-fns.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <title>Time and Date Demo</title>
+        <link rel="stylesheet" href="demo.css" />
+    </head>
+
+    <body>
+        <div>
+            <h3>@date-fns/tz compatibility test</h3>
+            <p>new TZDate(): <span id="tzdate"></span></p>
+            <p>new TZDate().withTimeZone('UTC'): <span id="tzdate-utc"></span></p>
+            <script type="module">
+                import { TZDate, TZDateMini } from 'https://cdn.jsdelivr.net/npm/@date-fns/tz@1.1.2/+esm'
+
+                const test = new TZDate()
+                console.warn('test instance check:', {
+                    // when Time Travel is active this is: true
+                    instanceOfDate: test instanceof Date,
+                    // when Time Travel is active this is: false!
+                    instanceOfTZDate: test instanceof TZDate,
+                    // when Time Travel is active this is: false!
+                    instanceOfTZDateMini: test instanceof TZDateMini,
+                })
+                console.log(test, test.__proto__)
+
+                document.getElementById('tzdate').textContent = test
+                document.getElementById('tzdate-utc').textContent = test.withTimeZone('UTC')
+            </script>
+        </div>
+    </body>
+</html>

--- a/src/test/date-fns.html
+++ b/src/test/date-fns.html
@@ -14,15 +14,11 @@
                 import { TZDate, TZDateMini } from 'https://cdn.jsdelivr.net/npm/@date-fns/tz@1.1.2/+esm'
 
                 const test = new TZDate()
-                console.warn('test instance check:', {
-                    // when Time Travel is active this is: true
+                console.log('instance check (all of these should be true):', {
                     instanceOfDate: test instanceof Date,
-                    // when Time Travel is active this is: false!
                     instanceOfTZDate: test instanceof TZDate,
-                    // when Time Travel is active this is: false!
                     instanceOfTZDateMini: test instanceof TZDateMini,
                 })
-                console.log(test, test.__proto__)
 
                 document.getElementById('tzdate').textContent = test
                 document.getElementById('tzdate-utc').textContent = test.withTimeZone('UTC')

--- a/src/test/scripts/replace_date.test.ts
+++ b/src/test/scripts/replace_date.test.ts
@@ -607,4 +607,20 @@ describe('replace_date', () => {
             })
         })
     })
+
+    /**
+     * e.g. @date-fns/tz iterates over all ownProperties of Date.prototype
+     *
+     * @see https://github.com/date-fns/tz/blob/213903702d7c5fcd4f01479ba7370fe917195a65/src/date/mini.js#L70
+     * @see https://github.com/cpulvermacher/time-travel/issues/41
+     */
+    it('Date should still have the same ownProperties when time travel is enabled', () => {
+        setFakeDate('')
+        const origProperties = Object.getOwnPropertyNames(Date.prototype)
+        expect(Date.name).toBe('Date')
+
+        setFakeDate('1970-01-01T00:00:00.123Z')
+        expect(Date.name).toBe('FakeDate')
+        expect(Object.getOwnPropertyNames(Date.prototype)).toStrictEqual(origProperties)
+    })
 })

--- a/src/test/scripts/replace_date.test.ts
+++ b/src/test/scripts/replace_date.test.ts
@@ -523,6 +523,30 @@ describe('replace_date', () => {
                 expect(intlString).toMatch(/Wednesday, September 15, 2021 at 12:34:56\WPM/)
             })
 
+            it('Intl.DateTimeFormat objects are instances of Intl.DateTimeFormat', () => {
+                const formatter = new Intl.DateTimeFormat('en-US', { dateStyle: 'full', timeStyle: 'medium' })
+                expect(formatter instanceof Intl.DateTimeFormat).toBeTruthy()
+            })
+
+            it('can inherit from Intl.DateTimeFormat', () => {
+                class MyDateTimeFormat extends Intl.DateTimeFormat {
+                    constructor() {
+                        super('en-US', { dateStyle: 'full', timeStyle: 'medium' })
+                    }
+                    myMethod() {
+                        return 'myMethod'
+                    }
+                }
+
+                const myFormatter = new MyDateTimeFormat()
+
+                expect(myFormatter instanceof Intl.DateTimeFormat).toBeTruthy()
+
+                // and also include the customization
+                expect(myFormatter instanceof MyDateTimeFormat).toBeTruthy()
+                expect(myFormatter.myMethod()).toEqual('myMethod')
+            })
+
             it('Intl.DateTimeFormat.format without class context', () => {
                 // assign without binding loses `this`
                 const format = new Intl.DateTimeFormat('en-GB', {

--- a/src/test/scripts/replace_date.test.ts
+++ b/src/test/scripts/replace_date.test.ts
@@ -474,6 +474,31 @@ describe('fake Date', () => {
                 expect(date.getUTCMilliseconds()).toEqual(123)
             })
 
+            it('can inherit from Date', () => {
+                class MyDate extends Date {
+                    constructor() {
+                        super()
+                    }
+                    myMethod() {
+                        return 'myMethod'
+                    }
+                }
+
+                const myDate = new MyDate()
+
+                // should be a (possibly fake) Date
+                expect(myDate instanceof Date).toBeTruthy()
+                if (fakeDate) {
+                    expect(myDate.toISOString()).toBe(fakeDate)
+                } else {
+                    expect(myDate.toISOString()).not.toBe(fakeDate)
+                }
+
+                // and also include the customization
+                expect(myDate instanceof MyDate).toBeTruthy()
+                expect(myDate.myMethod()).toEqual('myMethod')
+            })
+
             // static members
             it('UTC()', () => {
                 const ms = Date.UTC(1970, 0, 1, 0, 0, 3, 4)

--- a/src/test/scripts/replace_date.test.ts
+++ b/src/test/scripts/replace_date.test.ts
@@ -595,9 +595,9 @@ describe('replace_date', () => {
             })
 
             it('Intl.DateTimeFormat.prototype[@@toStringTag]', () => {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                expect((Intl.DateTimeFormat.prototype as any)[Symbol.toStringTag]).toBe('Intl.DateTimeFormat')
-                expect(new Intl.DateTimeFormat().toString()).toBe('[object Intl.DateTimeFormat]')
+                const format = new Intl.DateTimeFormat()
+                expect(Object.getPrototypeOf(format)[Symbol.toStringTag]).toBe('Intl.DateTimeFormat')
+                expect(format.toString()).toBe('[object Intl.DateTimeFormat]')
             })
 
             it('Intl.DateTimeFormat.supportedLocalesOf', () => {

--- a/src/test/scripts/replace_date.test.ts
+++ b/src/test/scripts/replace_date.test.ts
@@ -631,4 +631,15 @@ describe('replace_date', () => {
         expect(Date.name).toBe('FakeDate')
         expect(Object.getOwnPropertyNames(Date.prototype)).toStrictEqual(origProperties)
     })
+
+    it('getTimezoneOffset should return same value as original Date', () => {
+        setFakeDate('')
+        const dateString = '2010-07-01T00:00:00.000Z'
+        const originalOffset = new Date(dateString).getTimezoneOffset()
+        expect(isFinite(originalOffset)).toBeTruthy()
+
+        setFakeDate('2010-01-01T00:00:00.000Z')
+        //should be the same value for the same dateString
+        expect(new Date(dateString).getTimezoneOffset()).toBe(originalOffset)
+    })
 })

--- a/src/test/scripts/replace_date.test.ts
+++ b/src/test/scripts/replace_date.test.ts
@@ -6,7 +6,7 @@ import '../../scripts/replace_date'
 
 const testStartDate = new Date()
 
-describe('fake Date', () => {
+describe('replace_date', () => {
     afterEach(() => {
         window.sessionStorage.clear()
     })

--- a/src/test/scripts/replace_date.test.ts
+++ b/src/test/scripts/replace_date.test.ts
@@ -474,6 +474,10 @@ describe('fake Date', () => {
                 expect(date.getUTCMilliseconds()).toEqual(123)
             })
 
+            it('Date objects are Date instances', () => {
+                expect(new Date() instanceof Date).toBeTruthy()
+            })
+
             it('can inherit from Date', () => {
                 class MyDate extends Date {
                     constructor() {

--- a/src/test/scripts/replace_date.test.ts
+++ b/src/test/scripts/replace_date.test.ts
@@ -178,7 +178,7 @@ describe('fake Date', () => {
 
     const values = [undefined, '2010-01-01T00:00:00.000Z']
     values.forEach((fakeDate) => {
-        describe(`fake date = ${fakeDate}`, () => {
+        describe(`fake date = ${fakeDate ?? 'OFF'}`, () => {
             let date: Date
             let utcDate: Date
 
@@ -492,6 +492,18 @@ describe('fake Date', () => {
                 )
 
                 expect(intlString).toMatch(/Wednesday, September 15, 2021 at 12:34:56\WPM/)
+            })
+
+            it('Intl.DateTimeFormat.format without class context', () => {
+                // assign without binding loses `this`
+                const format = new Intl.DateTimeFormat('en-GB', {
+                    timeZone: 'JST',
+                    hour: 'numeric',
+                    timeZoneName: 'longOffset',
+                }).format
+
+                // check it matches the configured format anyway
+                expect(format(date)).toMatch(/[0-9]* GMT\+09:00/)
             })
 
             it('Intl.DateTimeFormat.formatToParts', () => {

--- a/src/test/scripts/replace_date.test.ts
+++ b/src/test/scripts/replace_date.test.ts
@@ -480,11 +480,17 @@ describe('replace_date', () => {
 
             it('can inherit from Date', () => {
                 class MyDate extends Date {
+                    value: string
+
                     constructor() {
                         super()
+                        this.value = 'value'
                     }
-                    myMethod() {
-                        return 'myMethod'
+                    method() {
+                        return 'method'
+                    }
+                    static staticMethod() {
+                        return 'staticMethod'
                     }
                 }
 
@@ -500,7 +506,9 @@ describe('replace_date', () => {
 
                 // and also include the customization
                 expect(myDate instanceof MyDate).toBeTruthy()
-                expect(myDate.myMethod()).toEqual('myMethod')
+                expect(myDate.method()).toEqual('method')
+                expect(myDate.value).toEqual('value')
+                expect(MyDate.staticMethod()).toEqual('staticMethod')
             })
 
             // static members


### PR DESCRIPTION
Fixes #41 by
- allowing calling Intl.DateTimeFormat.format() without a class instance
- fixing inheriting from Date