### PR TITLE
Keeping fake date keys on sessionStorage.clear

### DIFF
--- a/src/scripts/replace_date.ts
+++ b/src/scripts/replace_date.ts
@@ -1,5 +1,6 @@
 declare const __EXT_VERSION__: string
 ;(() => {
+    
     console.log(`Time Travel: injected content-script (version ${__EXT_VERSION__}) for host ${window.location.host}`)
     if (window['__timeTravelCheckToggle'] !== undefined) {
         // this can happen if multiple versions of the extension are installed
@@ -9,6 +10,24 @@ declare const __EXT_VERSION__: string
 
     const FAKE_DATE_STORAGE_KEY = 'timeTravelDate'
     const TICK_START_STORAGE_KEY = 'timeTravelTickStartTimestamp'
+
+    function overrideClearSessionStorage() {
+        const originalClear = sessionStorage.clear.bind(sessionStorage);
+        window.sessionStorage.clear = function () {
+            const fakeDate = getFromStorage(FAKE_DATE_STORAGE_KEY)
+            const tickStart = getFromStorage(TICK_START_STORAGE_KEY)
+
+            originalClear();
+
+            if (fakeDate) {
+                window.sessionStorage.setItem(FAKE_DATE_STORAGE_KEY, fakeDate)
+            }
+            if (tickStart) {
+                window.sessionStorage.setItem(TICK_START_STORAGE_KEY, tickStart)
+            }
+        }
+    }
+    overrideClearSessionStorage()
 
     // ==================== helper functions ====================
 

--- a/src/util/inject.ts
+++ b/src/util/inject.ts
@@ -1,25 +1,5 @@
 // all functions here are meant to be injected into the target page
 
-function overrideClearSessionStorage() {
-    //needs to be defined locally!
-    const FAKE_DATE_STORAGE_KEY = 'timeTravelDate'
-    const TICK_START_STORAGE_KEY = 'timeTravelTickStartTimestamp'
-
-    sessionStorage.clear = function () {
-        const fakeDate = sessionStorage.getItem(FAKE_DATE_STORAGE_KEY)
-        const tickStart = sessionStorage.getItem(TICK_START_STORAGE_KEY)
-
-        sessionStorage.clear()
-
-        if (fakeDate) {
-            sessionStorage.setItem(FAKE_DATE_STORAGE_KEY, fakeDate)
-        }
-        if (tickStart) {
-            sessionStorage.setItem(TICK_START_STORAGE_KEY, tickStart)
-        }
-    }
-}
-
 export function getFakeDate() {
     //needs to be defined locally!
     const FAKE_DATE_STORAGE_KEY = 'timeTravelDate'
@@ -27,7 +7,6 @@ export function getFakeDate() {
 }
 
 export function setFakeDate(date: string) {
-    overrideClearSessionStorage()
     //needs to be defined locally!
     const FAKE_DATE_STORAGE_KEY = 'timeTravelDate'
     if (date) {

--- a/src/util/inject.ts
+++ b/src/util/inject.ts
@@ -1,5 +1,25 @@
 // all functions here are meant to be injected into the target page
 
+function overrideClearSessionStorage() {
+    //needs to be defined locally!
+    const FAKE_DATE_STORAGE_KEY = 'timeTravelDate'
+    const TICK_START_STORAGE_KEY = 'timeTravelTickStartTimestamp'
+
+    sessionStorage.clear = function () {
+        const fakeDate = sessionStorage.getItem(FAKE_DATE_STORAGE_KEY)
+        const tickStart = sessionStorage.getItem(TICK_START_STORAGE_KEY)
+
+        sessionStorage.clear()
+
+        if (fakeDate) {
+            sessionStorage.setItem(FAKE_DATE_STORAGE_KEY, fakeDate)
+        }
+        if (tickStart) {
+            sessionStorage.setItem(TICK_START_STORAGE_KEY, tickStart)
+        }
+    }
+}
+
 export function getFakeDate() {
     //needs to be defined locally!
     const FAKE_DATE_STORAGE_KEY = 'timeTravelDate'
@@ -7,6 +27,7 @@ export function getFakeDate() {
 }
 
 export function setFakeDate(date: string) {
+    overrideClearSessionStorage()
     //needs to be defined locally!
     const FAKE_DATE_STORAGE_KEY = 'timeTravelDate'
     if (date) {


### PR DESCRIPTION
We were trying to use this with one of our web apps and it wasn't working, realised it's because our web app clears out sessionStorage on load, which means it's clearing out the keys this extension needs to work.

This PR overrides the sessionStorage.clear() function to keep the 2 keys required for this extension, but clear out everything else.

Keen to see your feedback, thanks